### PR TITLE
Change compile options (#7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ target_compile_options (
 	/Qpar
 	/utf-8
 	$<$<CONFIG:Debug>:
-		/GR
 		/JMC
 		/MDd
 		/Ob0
@@ -56,13 +55,19 @@ target_compile_options (
 	$<$<CONFIG:Release>:
 		/GA
 		/GL
-		/GR-
 		/Gy
 		/guard:cf-
 		/MT
 		/Os
 	>
 )
+
+IF (CMAKE_CXX_FLAGS MATCHES "/GR")
+	STRING (REPLACE "/GR" "/GR-" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+ELSE (CMAKE_CXX_FLAGS MATCHES "/GR")
+	SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ENDIF (CMAKE_CXX_FLAGS MATCHES "/GR")
+
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS_RELEASE "/NODEFAULTLIB:MSVCRT")
 
 target_link_options (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ add_library (${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE Zydis)
 
+set_property (TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set_property (TARGET Zydis PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 target_compile_features (${PROJECT_NAME} PUBLIC cxx_std_20)
 target_compile_definitions (
 	${PROJECT_NAME}
@@ -46,7 +49,7 @@ target_compile_options (
 	/utf-8
 	$<$<CONFIG:Debug>:
 		/JMC
-		/MDd
+		/LDd
 		/Ob0
 		/Od
 		/RTC1
@@ -57,7 +60,7 @@ target_compile_options (
 		/GL
 		/Gy
 		/guard:cf-
-		/MT
+		/LD
 		/Os
 	>
 )
@@ -67,8 +70,6 @@ IF (CMAKE_CXX_FLAGS MATCHES "/GR")
 ELSE (CMAKE_CXX_FLAGS MATCHES "/GR")
 	SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 ENDIF (CMAKE_CXX_FLAGS MATCHES "/GR")
-
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS_RELEASE "/NODEFAULTLIB:MSVCRT")
 
 target_link_options (
 	${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,16 +23,11 @@ target_compile_definitions (
 	${PROJECT_NAME}
 	PRIVATE
 	MEBIUS_EXPORT
-	WIN32
-	_WINDOWS
 	UNICODE
 	_UNICODE
 	$<$<CONFIG:Debug>: 
 		_DEBUG
 		DEBUG
-	>
-	$<$<CONFIG:Release>:
-		NDEBUG
 	>
 )
 
@@ -41,7 +36,6 @@ target_compile_options (
 	PRIVATE
 	/W4
 	/arch:AVX
-	/EHsc
 	/fp:fast
 	/GS
 	/GT
@@ -66,8 +60,6 @@ target_compile_options (
 		/Gy
 		/guard:cf-
 		/MT
-		/O2
-		/Oi
 		/Os
 	>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Zydis)
 set_property (TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 set_property (TARGET Zydis PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+set_property (TARGET ${PROJECT_NAME} PROPERTY MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug>:EditAndContinue>")
+set_property (TARGET Zydis PROPERTY MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug>:EditAndContinue>")
+
 target_compile_features (${PROJECT_NAME} PUBLIC cxx_std_20)
 target_compile_definitions (
 	${PROJECT_NAME}
@@ -53,7 +56,6 @@ target_compile_options (
 		/Ob0
 		/Od
 		/RTC1
-		/ZI
 	>
 	$<$<CONFIG:Release>:
 		/GA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,11 +77,24 @@ target_link_options (
 	/LTCG
 	/nologo
 	$<$<CONFIG:Debug>:
+		/nodefaultlib:libucrtd.lib
 		/debug
 		/opt:noref
 	>
 	$<$<CONFIG:Release>:
+		/nodefaultlib:libucrt.lib
 		/opt:ref
+	>
+)
+
+target_link_libraries (
+	${PROJECT_NAME}
+	PRIVATE
+	$<$<CONFIG:Debug>:
+		ucrtd.lib
+	>
+	$<$<CONFIG:Release>:
+		ucrt.lib
 	>
 )
 


### PR DESCRIPTION
# 変更主旨
#7 への対応として、VCRUNTIME140.dllおよびMSVCP140.dllを静的リンクするように変更しました。
なお、UCRTBASE.dllは依然として動的リンクさせています。

## 変更内容

`Mebius`および`Zydis`の`MSVC_RUNTIME_LIBRARY`プロパティを設定することで、プログラム全体を`/MT`オプション付きでコンパイルするように変更しました。

また、リンクオプションに`/nodefaultlib:libucrt.lib`を追加するとともに、新たに`ucrt.lib`を明示的にリンクさせることで、UCRTBASE.dllの動的リンクを保つようにしました。

# その他の変更

- `WIN32`, `_WINDOWS`, `NDEBUG`マクロおよび`/EHsc`, `/O2`オプションはCMake側で暗黙的に定義されていたため、明示的な定義を除去しました。
- `/GR`オプションは、CMake 3.19以前ではデフォルトでCMAKE_CXX_FLAGSに入っているため、`/GR-`との重複を避ける処理を追加しました。
- `/GR`オプションはDebug / Releaseにより変えるべきものではないため、Debug / Releaseともに`/GR-`となるように変更しました。
- "/ZI"オプションの指定を`MSVC_DEBUG_INFORMATION_FORMAT`プロパティを用いた方法に変更しました。