### PR TITLE
Change PluginsLoader to singleton

### DIFF
--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -48,7 +48,7 @@ namespace mebius {
 		void Load(const std::string& ext) noexcept {
 			for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
 				if (dir.path().extension() == ext) {
-					if (auto&& plugin = LoadLibraryA(dir.path().string().c_str())) {
+					if (auto&& plugin = LoadLibraryExA(dir.path().string().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
 						_plugins.emplace(std::move(plugin));
 					}
 				}

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -25,7 +25,7 @@ namespace mebius {
 				FreeLibrary(_handle);
 			}
 
-			operator HMODULE() const {
+			operator HMODULE() const noexcept {
 				return _handle;
 			}
 
@@ -47,13 +47,28 @@ namespace mebius {
 
 		void Load(const std::string& ext) noexcept {
 			for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
-				if (dir.path().extension() == ext) {
-					if (auto&& plugin = LoadLibraryExA(dir.path().string().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
+				if (dir.path().extension().string() == ext) {
+					if (auto&& plugin = LoadLibraryEx(dir.path().native().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
 						_plugins.emplace(std::move(plugin));
 					}
 				}
 			}
 		}
+
+		/*
+		* wstring実装
+		* 拡張子にワイド文字を使用することを考慮するならこちらを使用する
+		* 
+		void Load(const std::wstring& ext) noexcept {
+			for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
+				if (dir.path().extension().native() == ext) {
+					if (auto&& plugin = LoadLibraryEx(dir.path().native().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
+						_plugins.emplace(std::move(plugin));
+					}
+				}
+			}
+		}
+		*/
 
 	private:
 		const fs::path& _modsdir;

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -12,6 +12,28 @@ namespace mebius {
 
 	constexpr static inline char MODS_DIRNAME[] = "mods";
 
+	namespace internal {
+		class HModuleWrapper {
+		public:
+			HModuleWrapper(HMODULE&& handle) noexcept : _handle(handle) {}
+			HModuleWrapper(const HModuleWrapper&) = delete;
+			HModuleWrapper& operator=(const HModuleWrapper&) = delete;
+			HModuleWrapper(HModuleWrapper&&) = delete;
+			HModuleWrapper& operator=(HModuleWrapper&&) = delete;
+
+			~HModuleWrapper() noexcept {
+				FreeLibrary(_handle);
+			}
+
+			operator HMODULE() const {
+				return _handle;
+			}
+
+		private:
+			HMODULE _handle;
+		};
+	}
+
 	class PluginsLoader {
 	public:
 		static PluginsLoader& GetInstance() noexcept {
@@ -35,14 +57,10 @@ namespace mebius {
 
 	private:
 		const fs::path& _modsdir;
-		std::unordered_set<HMODULE> _plugins;
+		std::unordered_set<internal::HModuleWrapper> _plugins;
 
 		PluginsLoader() noexcept : _modsdir(std::move((fs::current_path() /= MODS_DIRNAME))), _plugins() {}
-		~PluginsLoader() noexcept {
-			for (auto&& plugin : _plugins) {
-				FreeLibrary(std::move(plugin));
-			}
-		}
+		~PluginsLoader() noexcept = default;
 	};
 }
 

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -19,7 +19,7 @@ namespace mebius {
 			{
 				if (p.path().extension() == ext) {
 					if (HMODULE lib = LoadLibraryA(p.path().string().c_str())) {
-						// ƒ[ƒh‚µ‚½î•ñ‚ğŒŸõ‚µ‚Ä”í‚è‚ª‚È‚¯‚ê‚ÎVector‚É’Ç‰Á
+						// ãƒ­ãƒ¼ãƒ‰ã—ãŸæƒ…å ±ã‚’æ¤œç´¢ã—ã¦è¢«ã‚ŠãŒãªã‘ã‚Œã°Vectorã«è¿½åŠ 
 						if (std::find(_plugins.begin(), _plugins.end(), lib) == _plugins.end()) {
 							_plugins.push_back(std::move(lib));
 						}

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -7,9 +7,9 @@
 #include <filesystem>
 #include <vector>
 
-namespace fs = std::filesystem;
-
 namespace mebius {
+	namespace fs = std::filesystem;
+
 	void FreePlugins(void);
 
 	class PluginsLoader {

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -26,6 +26,10 @@ namespace mebius {
 					FreeLibrary(_handle);
 				}
 
+				bool operator==(const HModuleWrapper& left) const noexcept {
+					return _handle == left._handle;
+				}
+
 				operator HMODULE() const noexcept {
 					return _handle;
 				}
@@ -34,7 +38,21 @@ namespace mebius {
 				HMODULE _handle;
 			};
 		}
+	}
+}
 
+namespace std {
+	template<>
+	class std::hash<mebius::plugin::internal::HModuleWrapper> {
+	public:
+		size_t operator()(const mebius::plugin::internal::HModuleWrapper& mod) const noexcept {
+			return std::bit_cast<size_t>((HANDLE)mod);
+		}
+	};
+}
+
+namespace mebius {
+	namespace plugin {
 		class PluginsLoader {
 		public:
 			static PluginsLoader& GetInstance() noexcept {

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -8,74 +8,75 @@
 #include <unordered_set>
 
 namespace mebius {
-	namespace fs = std::filesystem;
+	namespace plugin {
+		namespace fs = std::filesystem;
 
-	constexpr static inline char MODS_DIRNAME[] = "mods";
+		constexpr static inline char MODS_DIRNAME[] = "mods";
 
-	namespace internal {
-		class HModuleWrapper {
+		namespace internal {
+			class HModuleWrapper {
+			public:
+				HModuleWrapper(HMODULE&& handle) noexcept : _handle(handle) {}
+				HModuleWrapper(const HModuleWrapper&) = delete;
+				HModuleWrapper& operator=(const HModuleWrapper&) = delete;
+				HModuleWrapper(HModuleWrapper&&) = delete;
+				HModuleWrapper& operator=(HModuleWrapper&&) = delete;
+
+				~HModuleWrapper() noexcept {
+					FreeLibrary(_handle);
+				}
+
+				operator HMODULE() const noexcept {
+					return _handle;
+				}
+
+			private:
+				HMODULE _handle;
+			};
+		}
+
+		class PluginsLoader {
 		public:
-			HModuleWrapper(HMODULE&& handle) noexcept : _handle(handle) {}
-			HModuleWrapper(const HModuleWrapper&) = delete;
-			HModuleWrapper& operator=(const HModuleWrapper&) = delete;
-			HModuleWrapper(HModuleWrapper&&) = delete;
-			HModuleWrapper& operator=(HModuleWrapper&&) = delete;
+			static PluginsLoader& GetInstance() noexcept {
+				static PluginsLoader instance{};
+				return instance;
+			}
+			PluginsLoader(const PluginsLoader&) = delete;
+			PluginsLoader& operator=(const PluginsLoader&) = delete;
+			PluginsLoader(PluginsLoader&&) = delete;
+			PluginsLoader& operator=(PluginsLoader&&) = delete;
 
-			~HModuleWrapper() noexcept {
-				FreeLibrary(_handle);
+			void Load(const std::string& ext) noexcept {
+				for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
+					if (dir.path().extension().string() == ext) {
+						if (auto&& plugin = LoadLibraryEx(dir.path().native().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
+							_plugins.emplace(std::move(plugin));
+						}
+					}
+				}
 			}
 
-			operator HMODULE() const noexcept {
-				return _handle;
+			/*
+			* wstring実装
+			* 拡張子にワイド文字を使用することを考慮するならこちらを使用する
+			*
+			void Load(const std::wstring& ext) noexcept {
+				for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
+					if (dir.path().extension().native() == ext) {
+						if (auto&& plugin = LoadLibraryEx(dir.path().native().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
+							_plugins.emplace(std::move(plugin));
+						}
+					}
+				}
 			}
+			*/
 
 		private:
-			HMODULE _handle;
+			const fs::path& _modsdir;
+			std::unordered_set<internal::HModuleWrapper> _plugins;
+
+			PluginsLoader() noexcept : _modsdir(std::move((fs::current_path() /= MODS_DIRNAME))), _plugins() {}
+			~PluginsLoader() noexcept = default;
 		};
 	}
-
-	class PluginsLoader {
-	public:
-		static PluginsLoader& GetInstance() noexcept {
-			static PluginsLoader instance{};
-			return instance;
-		}
-		PluginsLoader(const PluginsLoader&) = delete;
-		PluginsLoader& operator=(const PluginsLoader&) = delete;
-		PluginsLoader(PluginsLoader&&) = delete;
-		PluginsLoader& operator=(PluginsLoader&&) = delete;
-
-		void Load(const std::string& ext) noexcept {
-			for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
-				if (dir.path().extension().string() == ext) {
-					if (auto&& plugin = LoadLibraryEx(dir.path().native().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
-						_plugins.emplace(std::move(plugin));
-					}
-				}
-			}
-		}
-
-		/*
-		* wstring実装
-		* 拡張子にワイド文字を使用することを考慮するならこちらを使用する
-		* 
-		void Load(const std::wstring& ext) noexcept {
-			for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
-				if (dir.path().extension().native() == ext) {
-					if (auto&& plugin = LoadLibraryEx(dir.path().native().c_str(), NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)) {
-						_plugins.emplace(std::move(plugin));
-					}
-				}
-			}
-		}
-		*/
-
-	private:
-		const fs::path& _modsdir;
-		std::unordered_set<internal::HModuleWrapper> _plugins;
-
-		PluginsLoader() noexcept : _modsdir(std::move((fs::current_path() /= MODS_DIRNAME))), _plugins() {}
-		~PluginsLoader() noexcept = default;
-	};
 }
-

--- a/include/_Plugin.hpp
+++ b/include/_Plugin.hpp
@@ -5,7 +5,7 @@
 #include "Plugin.hpp"
 #include <Windows.h>
 #include <filesystem>
-#include <vector>
+#include <unordered_set>
 
 namespace mebius {
 	namespace fs = std::filesystem;
@@ -27,9 +27,7 @@ namespace mebius {
 			for (auto&& dir : fs::recursive_directory_iterator(_modsdir)) {
 				if (dir.path().extension() == ext) {
 					if (auto&& plugin = LoadLibraryA(dir.path().string().c_str())) {
-						if (std::find(_plugins.begin(), _plugins.end(), plugin) == _plugins.end()) {
-							_plugins.emplace_back(std::move(plugin));
-						}
+						_plugins.emplace(std::move(plugin));
 					}
 				}
 			}
@@ -37,7 +35,7 @@ namespace mebius {
 
 	private:
 		const fs::path& _modsdir;
-		std::vector<HMODULE> _plugins;
+		std::unordered_set<HMODULE> _plugins;
 
 		PluginsLoader() noexcept : _modsdir(std::move((fs::current_path() /= MODS_DIRNAME))), _plugins() {}
 		~PluginsLoader() noexcept {

--- a/src/Plugin.cpp
+++ b/src/Plugin.cpp
@@ -3,5 +3,5 @@
 using namespace mebius;
 
 void mebius::LoadPlugins(const std::string & ext) {
-    PluginsLoader::GetInstance().Load(ext);
+    plugin::PluginsLoader::GetInstance().Load(ext);
 }

--- a/src/Plugin.cpp
+++ b/src/Plugin.cpp
@@ -2,12 +2,6 @@
 
 using namespace mebius;
 
-std::vector<HMODULE> PluginsLoader::_plugins;
-
 void mebius::LoadPlugins(const std::string & ext) {
-    std::shared_ptr <PluginsLoader> loader(new PluginsLoader(ext));
-}
-
-void mebius::FreePlugins() {
-    PluginsLoader::free();
+    PluginsLoader::GetInstance().Load(ext);
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -18,7 +18,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
         break;
     }
     case DLL_PROCESS_DETACH: {
-        FreePlugins();
         break;
     }
     }


### PR DESCRIPTION
# 変更主旨
PluginsLoaderをシングルトンで再実装しました。

# その他の変更
- コンパイル時警告の解決のため、ファイルの文字コードをSJISからBOMなしUTF-8に変更しました。
- 衝突防止のため、名前空間aliasをmebius::plugin名前空間内に移動させました。
- 衝突防止のため、PluginsLoaderクラスをmebius::plugin名前空間へ移動させました。
- 重複登録回避用処理を省くため、_pluginsを`std::vector`から`std::unoredered_set`に変更しました。
- セキュリティ向上のため、LoadLibraryをLoadLibraryExに置換しました。
- ファイルパスやファイル名にワイド文字が含まれる場合に対応させました。
  + 引数がstringである都合上、拡張子がワイド文字の場合は非対応です。
  （ただし、引数がwstringのパターンのコードも用意しておきました。）